### PR TITLE
Fix href for sushiswap.vision

### DIFF
--- a/src/components/PositionCard/index.tsx
+++ b/src/components/PositionCard/index.tsx
@@ -224,7 +224,7 @@ export default function FullPositionCard({ pair, border }: PositionCardProps) {
             </FixedHeightRow>
 
             <AutoRow justify="center" marginTop={'10px'}>
-              <ExternalLink href={`https://sushiswap.vision/token/${pair.liquidityToken.address}`}>
+              <ExternalLink href={`https://sushiswap.vision/pair/${pair.liquidityToken.address}`}>
                 View pool information ↗
               </ExternalLink>
             </AutoRow>


### PR DESCRIPTION
Should redirect to pair, not listed token.